### PR TITLE
webOrderLineItemId moved to RenewableReceipt class. method initializeByObject checks whether fields are set

### DIFF
--- a/source/Response/Receipt.php
+++ b/source/Response/Receipt.php
@@ -8,7 +8,7 @@ use AppStore\Client\ObjectInitializedInterface;
  * Purchases receipt class
  * @author alxmsl
  * @date 2/14/13
- */ 
+ */
 class Receipt implements ObjectInitializedInterface {
     /**
      * @var int number of purchased items
@@ -60,16 +60,11 @@ class Receipt implements ObjectInitializedInterface {
      */
     private $bvrs = '';
 
-	/**
-	 * @var string The primary key for identifying subscription purchases
-	 */
-	private $webOrderLineItemId = '';
-
-	/**
-	 * @var string For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
-	 * Treat a canceled receipt the same as if no purchase had ever been made
-	 */
-	private $cancellationDate = '';
+    /**
+     * @var string For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
+     * Treat a canceled receipt the same as if no purchase had ever been made
+     */
+    private $cancellationDate = '';
 
     /**
      * Setter for application identifier from App Store
@@ -251,47 +246,27 @@ class Receipt implements ObjectInitializedInterface {
         return $this->versionExternalIdentifier;
     }
 
-	/**
-	 * The primary key for identifying subscription purchases
-	 * @param string $webOrderLineItemId
-	 * @return $this
-	 */
-	public function setWebOrderLineItemId($webOrderLineItemId)
-	{
-		$this->webOrderLineItemId = $webOrderLineItemId;
-		return $this;
-	}
+    /**
+     * For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
+     * Treat a canceled receipt the same as if no purchase had ever been made.
+     * @return string
+     */
+    public function getCancellationDate()
+    {
+        return $this->cancellationDate;
+    }
 
-	/**
-	 * The primary key for identifying subscription purchases
-	 * @return string
-	 */
-	public function getWebOrderLineItemId()
-	{
-		return $this->webOrderLineItemId;
-	}
-
-	/**
-	 * For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
-	 * Treat a canceled receipt the same as if no purchase had ever been made.
-	 * @return string
-	 */
-	public function getCancellationDate()
-	{
-		return $this->cancellationDate;
-	}
-
-	/**
-	 * For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
-	 * Treat a canceled receipt the same as if no purchase had ever been made.
-	 * @param string $cancellationDate
-	 * @return $this
-	 */
-	public function setCancellationDate($cancellationDate)
-	{
-		$this->cancellationDate = $cancellationDate;
-		return $this;
-	}
+    /**
+     * For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
+     * Treat a canceled receipt the same as if no purchase had ever been made.
+     * @param string $cancellationDate
+     * @return $this
+     */
+    public function setCancellationDate($cancellationDate)
+    {
+        $this->cancellationDate = $cancellationDate;
+        return $this;
+    }
 
     /**
      * Initialization method
@@ -300,21 +275,46 @@ class Receipt implements ObjectInitializedInterface {
      */
     public static function initializeByObject(\stdClass $Object) {
         $Receipt = new self();
-        $Receipt->setAppItemId($Object->app_item_id)
-            ->setBid($Object->bid)
-            ->setBvrs($Object->bvrs)
-            ->setOriginalPurchaseDate($Object->original_purchase_date)
-            ->setOriginalTransactionId($Object->original_transaction_id)
-            ->setProductId($Object->product_id)
-            ->setPurchaseDate($Object->purchase_date)
-            ->setQuantity($Object->quantity)
-            ->setTransactionId($Object->transaction_id)
-			->setWebOrderLineItemId($Object->web_order_line_item_id)
-            ->setQuantity($Object->quantity);
 
-		if ($Object->cancellation_date) {
-			$Receipt->setCancellationDate($Object->cancellation_date);
-		}
+        if (isset($Object->app_item_id)) {
+            $Receipt->setAppItemId($Object->app_item_id);
+        }
+
+        if (isset($Object->bid)) {
+            $Receipt->setBid($Object->bid);
+        }
+
+        if (isset($Object->bvrs)) {
+            $Receipt->setBvrs($Object->bvrs);
+        }
+
+        if (isset($Object->product_id)) {
+            $Receipt->setProductId($Object->product_id);
+        }
+
+        if (isset($Object->quantity)) {
+            $Receipt->setQuantity($Object->quantity);
+        }
+
+        if (isset($Object->transaction_id)) {
+            $Receipt->setTransactionId($Object->transaction_id);
+        }
+
+        if (isset($Object->original_transaction_id)) {
+            $Receipt->setOriginalTransactionId($Object->original_transaction_id);
+        }
+
+        if (isset($Object->purchase_date)) {
+            $Receipt->setPurchaseDate($Object->purchase_date);
+        }
+
+        if (isset($Object->original_purchase_date)) {
+            $Receipt->setOriginalPurchaseDate($Object->original_purchase_date);
+        }
+
+        if (isset($Object->cancellation_date)) {
+            $Receipt->setCancellationDate($Object->cancellation_date);
+        }
 
         return $Receipt;
     }

--- a/source/Response/RenewableReceipt.php
+++ b/source/Response/RenewableReceipt.php
@@ -6,12 +6,17 @@ namespace AppStore\Client\Response;
  * Auto-renewable receipt class
  * @author alxmsl
  * @date 2/14/13
- */ 
+ */
 final class RenewableReceipt extends Receipt {
     /**
      * @var int expiration timestamp, msec
      */
     private $expiresDate = 0;
+
+    /**
+     * @var string The primary key for identifying subscription purchases
+     */
+    private $webOrderLineItemId = '';
 
     /**
      * Setter for expiration timestamp
@@ -32,24 +37,81 @@ final class RenewableReceipt extends Receipt {
     }
 
     /**
+     * The primary key for identifying subscription purchases
+     * @param string $webOrderLineItemId
+     * @return $this
+     */
+    public function setWebOrderLineItemId($webOrderLineItemId)
+    {
+        $this->webOrderLineItemId = $webOrderLineItemId;
+        return $this;
+    }
+
+    /**
+     * The primary key for identifying subscription purchases
+     * @return string
+     */
+    public function getWebOrderLineItemId()
+    {
+        return $this->webOrderLineItemId;
+    }
+
+    /**
      * Initialization method
      * @param \stdClass $Object object for initialization
      * @return RenewableReceipt initialized receipt for auto-renewable subscription
      */
     public static function initializeByObject(\stdClass $Object) {
-        $RenewableReceipt = new self();
-        $RenewableReceipt->setExpiresDate($Object->expires_date)
-            ->setAppItemId($Object->app_item_id)
-            ->setBid($Object->bid)
-            ->setBvrs($Object->bvrs)
-            ->setOriginalPurchaseDate($Object->original_purchase_date)
-            ->setOriginalTransactionId($Object->original_transaction_id)
-            ->setProductId($Object->product_id)
-            ->setPurchaseDate($Object->purchase_date)
-            ->setQuantity($Object->quantity)
-            ->setTransactionId($Object->transaction_id)
-			->setWebOrderLineItemId($Object->web_order_line_item_id)
-            ->setQuantity($Object->quantity);
-        return $RenewableReceipt;
+        $Receipt = new self();
+
+        if (isset($Object->app_item_id)) {
+            $Receipt->setAppItemId($Object->app_item_id);
+        }
+
+        if (isset($Object->bid)) {
+            $Receipt->setBid($Object->bid);
+        }
+
+        if (isset($Object->bvrs)) {
+            $Receipt->setBvrs($Object->bvrs);
+        }
+
+        if (isset($Object->product_id)) {
+            $Receipt->setProductId($Object->product_id);
+        }
+
+        if (isset($Object->quantity)) {
+            $Receipt->setQuantity($Object->quantity);
+        }
+
+        if (isset($Object->transaction_id)) {
+            $Receipt->setTransactionId($Object->transaction_id);
+        }
+
+        if (isset($Object->original_transaction_id)) {
+            $Receipt->setOriginalTransactionId($Object->original_transaction_id);
+        }
+
+        if (isset($Object->purchase_date)) {
+            $Receipt->setPurchaseDate($Object->purchase_date);
+        }
+
+        if (isset($Object->original_purchase_date)) {
+            $Receipt->setOriginalPurchaseDate($Object->original_purchase_date);
+        }
+
+        if (isset($Object->cancellation_date)) {
+            $Receipt->setCancellationDate($Object->cancellation_date);
+        }
+
+        if (isset($Object->web_order_line_item_id)) {
+            $Receipt->setWebOrderLineItemId($Object->web_order_line_item_id);
+        }
+
+        if (isset($Object->expires_date)) {
+            $Receipt->setExpiresDate($Object->expires_date);
+        }
+
+        return $Receipt;
     }
 }


### PR DESCRIPTION
webOrderLineItemId moved to RenewableReceipt class. 
method initializeByObject checks whether fields are set
