### PR TITLE
fixed versionExternalIdentifier initialization for AppReceipt

### DIFF
--- a/source/Response/iOS7/AppReceipt.php
+++ b/source/Response/iOS7/AppReceipt.php
@@ -113,7 +113,7 @@ final class AppReceipt implements ObjectInitializedInterface {
         if (property_exists($Object, 'original_application_version')) {
             $AppReceipt->originalApplicationVersion = (string) $Object->original_application_version;
         }
-        $AppReceipt->versionExternalIdentifier = (string) $Object->versionExternalIdentifier;
+        $AppReceipt->versionExternalIdentifier = (string) $Object->version_external_identifier;
 
         foreach ($Object->in_app as $PurchaseObject) {
             $AppReceipt->inAppPurchaseReceipts[] = InAppPurchaseReceipt::initializeByObject($PurchaseObject);


### PR DESCRIPTION
AppStore returns underscore names, not camel case.
